### PR TITLE
Bulk Canceling  Auctions

### DIFF
--- a/MysticMaestro/REMenu.lua
+++ b/MysticMaestro/REMenu.lua
@@ -600,6 +600,7 @@ local statsContainerWidgets = {}
 do -- show and hide MysticMaestroMenu
 
 	local automationFunctionNames = {
+		"Cancel Auctions",
 		"Batch Scan",
 		"Queue Scan",
 		"GetAll Scan",

--- a/MysticMaestro/automation/AutomationManager.lua
+++ b/MysticMaestro/automation/AutomationManager.lua
@@ -180,6 +180,8 @@ local function handleRunningStatus(status)
 		terminateAutomation()
 	elseif status == "pauseClicked" then
 		pauseAutomation()
+	elseif status == "nextBatchClicked" then
+		currentAutomationTable.ProcessBatch()
 	else
 		logStatusError(status)
 	end

--- a/MysticMaestro/automation/automationCommon.lua
+++ b/MysticMaestro/automation/automationCommon.lua
@@ -304,8 +304,10 @@ MM.AutomationUtil.RegisterPopupTemplate("prompt",
 local function createRunningWidgets(self)
 	if currentAutomationTable.Pause then
 		MM.AutomationUtil.CreateButtonWidget(self, currentAutomationTable, "Pause", "pauseClicked", -45, -70)
+	elseif currentAutomationTable.ProcessBatch then
+		MM.AutomationUtil.CreateButtonWidget(self, currentAutomationTable, "Next", "nextBatchClicked", -45, -70)
 	end
-	MM.AutomationUtil.CreateButtonWidget(self, currentAutomationTable, "Stop", "stopClicked", currentAutomationTable.Pause and 45 or 0, -70)
+	MM.AutomationUtil.CreateButtonWidget(self, currentAutomationTable, "Stop", "stopClicked", currentAutomationTable.Pause or currentAutomationTable.ProcessBatch and 45 or 0, -70)
 end
 
 MM.AutomationUtil.RegisterPopupTemplate("running",

--- a/MysticMaestro/automation/automationCommon.lua
+++ b/MysticMaestro/automation/automationCommon.lua
@@ -133,7 +133,9 @@ function MM.AutomationUtil.CreateButtonWidget(automationTable, text, informStatu
 	button:SetPoint("TOP", automationPopupFrame, "TOP", xOffset, yOffset)
 	button:SetCallback("OnClick",
 		function()
-			MM.AutomationUtil.HideAutomationPopup(currentAutomationTable)
+			if informStatus ~= "nextBatchClicked" then
+				MM.AutomationUtil.HideAutomationPopup(currentAutomationTable)
+			end
 			MM.AutomationManager:Inform(automationTable, informStatus)
 		end
 	)

--- a/MysticMaestro/automation/functions/cancel.lua
+++ b/MysticMaestro/automation/functions/cancel.lua
@@ -28,7 +28,7 @@ local function initCanceling()
 		local scrollName=data[1]:match("^Mystic Scroll: ([%w%s'-]+)")
 		local bid=data[10]
 		local timeIndex=GetAuctionItemTimeLeft("owner",i)
-		if (timeIndex<=4 and bid==0 and scrollName) then
+		if (timeIndex<4 and bid==0 and scrollName) then
 			 table.insert(cancelList,i)
 		end
 		table.sort(cancelList, function(a,b) return a > b end)
@@ -36,15 +36,13 @@ local function initCanceling()
 end
 
 local function nilCancelScanVariables()
-	MM:Print("Setting Cancel variables to nil")
 	running = false
 	currentCancel = nil
 	totalCanceled = nil
 	cancelList = nil
 end
 
-
-local function Process()
+function automationTable.ProcessBatch()
 	if running then
 		if totalCanceled < #cancelList then
 			local tally = 0
@@ -57,21 +55,14 @@ local function Process()
 			end
 			MM.AutomationUtil.SetProgressBarValues(automationTable, currentCancel, #cancelList)
 			if totalCanceled >= #cancelList then
-				MM:Print("totalCanceled is greater than or equal to the cancelList length")
 				nilCancelScanVariables()
 				MM.AutomationManager:Inform(automationTable, "finished")
 			end
 		else
-				MM:Print("Batch Attempted but totalCanceled >= cancelList length")
 				nilCancelScanVariables()
 				MM.AutomationManager:Inform(automationTable, "finished")
 		end
-
 	end
-end
-
-function automationTable.ProcessBatch()
-	Process()
 end
 
 function automationTable.Start()
@@ -84,11 +75,10 @@ function automationTable.Start()
 	if #cancelList <= 0 then
 		MM:Print("Nothing within cancel duration")
 	end
-	-- automationTable.ProcessBatch()
+	automationTable.ProcessBatch()
 end
 
 function automationTable.Stop()
-	MM:Print("Automation is stopped")
 	MM.AutomationUtil.HideAutomationPopup(automationTable)
 	nilCancelScanVariables()
 end


### PR DESCRIPTION
Add a new automation functionality, to cancel all auctions with a duration less than 4.

eventually we will want to have an option configured to set this value from 1 to 4, so it will cancel auctions up to the value specified:

    1
        short (less than 30 minutes)
    2
        medium (30 minutes - 2 hours)
    3
        long (2 - 12 hours)
    4
        very long (more than 12 hours)